### PR TITLE
[BE] feat: 카드 삭제를 위한 기능 구현 (#12)

### DIFF
--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/controller/TaskController.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/controller/TaskController.java
@@ -1,14 +1,17 @@
 package codesquad.todolist.travelers.task.controller;
 
 import codesquad.todolist.travelers.global.ApiResponse;
+import codesquad.todolist.travelers.task.domain.dto.request.TaskUpdateRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.response.ProcessResponseDto;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskRequestDto;
+import codesquad.todolist.travelers.task.domain.entity.Task;
 import codesquad.todolist.travelers.task.service.TaskService;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -44,5 +47,14 @@ public class TaskController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success("200", "카드 삭제 성공!"));
+    }
+
+    @PatchMapping("/task/{taskId}")
+    public ResponseEntity<ApiResponse<?>> delete(@PathVariable Long taskId,
+                                                 @RequestBody final TaskUpdateRequestDto taskUpdateRequestDto) {
+        taskService.updateTask(taskId, taskUpdateRequestDto);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success("200", taskUpdateRequestDto));
     }
 }

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/controller/TaskController.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/controller/TaskController.java
@@ -55,6 +55,6 @@ public class TaskController {
         taskService.updateTask(taskId, taskUpdateRequestDto);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.success("200", taskUpdateRequestDto));
+                .body(ApiResponse.success("200", "카드 수정 성공!"));
     }
 }

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/dto/request/TaskUpdateRequestDto.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/dto/request/TaskUpdateRequestDto.java
@@ -1,0 +1,28 @@
+package codesquad.todolist.travelers.task.domain.dto.request;
+
+import codesquad.todolist.travelers.task.domain.entity.Task;
+
+public class TaskUpdateRequestDto {
+    private String title;
+    private String contents;
+
+    public TaskUpdateRequestDto() {
+    }
+
+    public TaskUpdateRequestDto(String title, String contents) {
+        this.title = title;
+        this.contents = contents;
+    }
+
+    public Task toEntity() {
+        return new Task(null, title, contents, null, null, null);
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContents() {
+        return contents;
+    }
+}

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/repository/JdbcTaskRepositoryImpl.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/repository/JdbcTaskRepositoryImpl.java
@@ -35,11 +35,25 @@ public class JdbcTaskRepositoryImpl implements TaskRepository {
     }
 
     @Override
-    public void deleteBy(Long taskId) {
+    public void deleteBy(final Long taskId) {
         String sql = "DELETE FROM task " +
                 "WHERE task_id = :taskId";
 
         Map<String, Object> param = Map.of("taskId", taskId);
+
+        template.update(sql, param);
+    }
+
+    @Override
+    public void updateBy(final Long taskId, final Task task) {
+        String sql = "UPDATE task " +
+                "SET title=:title, contents=:contents " +
+                "WHERE task_id = :taskId";
+
+        SqlParameterSource param = new MapSqlParameterSource()
+                .addValue("title", task.getTitle())
+                .addValue("contents", task.getContents())
+                .addValue("taskId", taskId);
 
         template.update(sql, param);
     }

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/repository/TaskRepository.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/repository/TaskRepository.java
@@ -9,6 +9,8 @@ public interface TaskRepository {
 
     void deleteBy(final Long taskId);
 
+    void updateBy(final Long taskId, final Task task);
+
     List<Task> findAllBy(final Long processId);
 
     List<Process> findProcesses();

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/service/TaskService.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/service/TaskService.java
@@ -1,9 +1,11 @@
 package codesquad.todolist.travelers.task.service;
 
+import codesquad.todolist.travelers.task.domain.dto.request.TaskUpdateRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.response.ProcessResponseDto;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.response.TaskResponseDto;
 import codesquad.todolist.travelers.task.domain.entity.Process;
+import codesquad.todolist.travelers.task.domain.entity.Task;
 import codesquad.todolist.travelers.task.domain.repository.TaskRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,6 +28,10 @@ public class TaskService {
 
     public void deleteTask(final Long taskId) {
         taskRepository.deleteBy(taskId);
+    }
+
+    public void updateTask(final Long taskId, final TaskUpdateRequestDto task) {
+        taskRepository.updateBy(taskId, task.toEntity());
     }
 
     public List<ProcessResponseDto> getProcesses() {


### PR DESCRIPTION
## 구현 내용

- 카드 삭제를 위한 기능 구현

## 확인 내용

- 컨트롤러에 title, contents만을 담는 DTO 생성 후 Service에 전달
- update, delete 레포지토리에 리턴되는 값 없음

## 남은 할 일

- 카드 이동, 테스트 코드