### PR TITLE
[BE] feat: 카드 이동을 위한 기능 구현 (#13)

### DIFF
--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/controller/TaskController.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/controller/TaskController.java
@@ -1,10 +1,10 @@
 package codesquad.todolist.travelers.task.controller;
 
 import codesquad.todolist.travelers.global.ApiResponse;
+import codesquad.todolist.travelers.task.domain.dto.request.TaskProcessIdRequestDto;
+import codesquad.todolist.travelers.task.domain.dto.request.TaskRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskUpdateRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.response.ProcessResponseDto;
-import codesquad.todolist.travelers.task.domain.dto.request.TaskRequestDto;
-import codesquad.todolist.travelers.task.domain.entity.Task;
 import codesquad.todolist.travelers.task.service.TaskService;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -42,7 +42,7 @@ public class TaskController {
     }
 
     @DeleteMapping("/task/{taskId}")
-    public ResponseEntity<ApiResponse<?>> delete(@PathVariable Long taskId) {
+    public ResponseEntity<ApiResponse<?>> delete(@PathVariable final Long taskId) {
         taskService.deleteTask(taskId);
 
         return ResponseEntity.status(HttpStatus.OK)
@@ -50,11 +50,20 @@ public class TaskController {
     }
 
     @PatchMapping("/task/{taskId}")
-    public ResponseEntity<ApiResponse<?>> delete(@PathVariable Long taskId,
+    public ResponseEntity<ApiResponse<?>> update(@PathVariable final Long taskId,
                                                  @RequestBody final TaskUpdateRequestDto taskUpdateRequestDto) {
         taskService.updateTask(taskId, taskUpdateRequestDto);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success("200", "카드 수정 성공!"));
+    }
+
+    @PatchMapping("/task/process/{taskId}")
+    public ResponseEntity<ApiResponse<?>> move(@PathVariable final Long taskId,
+                                               @RequestBody final TaskProcessIdRequestDto taskProcessIdRequestDto) {
+        taskService.updateTaskByProcess(taskProcessIdRequestDto, taskId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success("200", "카드 이동 성공!"));
     }
 }

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/dto/request/TaskProcessIdRequestDto.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/dto/request/TaskProcessIdRequestDto.java
@@ -1,0 +1,16 @@
+package codesquad.todolist.travelers.task.domain.dto.request;
+
+public class TaskProcessIdRequestDto {
+    private Long processId;
+
+    public TaskProcessIdRequestDto() {
+    }
+
+    public TaskProcessIdRequestDto(Long processId) {
+        this.processId = processId;
+    }
+
+    public Long getProcessId() {
+        return processId;
+    }
+}

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/dto/response/TaskResponseDto.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/dto/response/TaskResponseDto.java
@@ -8,16 +8,12 @@ public class TaskResponseDto {
     private final String title;
     private final String contents;
     private final String platform;
-    private final LocalDateTime createdTime;
-    private final Long processId;
 
     public TaskResponseDto(final Task task) {
         this.taskId = task.getTaskId();
         this.title = task.getTitle();
         this.contents = task.getContents();
         this.platform = task.getPlatform();
-        this.createdTime = task.getCreatedTime();
-        this.processId = task.getProcessId();
     }
 
     public Long getTaskId() {
@@ -34,13 +30,5 @@ public class TaskResponseDto {
 
     public String getPlatform() {
         return platform;
-    }
-
-    public LocalDateTime getCreatedTime() {
-        return createdTime;
-    }
-
-    public Long getProcessId() {
-        return processId;
     }
 }

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/repository/JdbcTaskRepositoryImpl.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/repository/JdbcTaskRepositoryImpl.java
@@ -47,7 +47,7 @@ public class JdbcTaskRepositoryImpl implements TaskRepository {
     @Override
     public void updateBy(final Long taskId, final Task task) {
         String sql = "UPDATE task " +
-                "SET title=:title, contents=:contents " +
+                "SET title = :title, contents = :contents " +
                 "WHERE task_id = :taskId";
 
         SqlParameterSource param = new MapSqlParameterSource()
@@ -59,8 +59,21 @@ public class JdbcTaskRepositoryImpl implements TaskRepository {
     }
 
     @Override
+    public void updateTaskBy(Long processId, Long taskId) {
+        String sql = "UPDATE task " +
+                "SET process_id = :processId " +
+                "WHERE task_id = :taskId";
+
+        SqlParameterSource param = new MapSqlParameterSource()
+                .addValue("processId", processId)
+                .addValue("taskId", taskId);
+
+        template.update(sql, param);
+    }
+
+    @Override
     public List<Task> findAllBy(final Long processId) {
-        String sql = "SELECT t.task_id, t.title, t.contents, t.platform, t.created_time, t.process_id, p.name "
+        String sql = "SELECT t.task_id, t.title, t.contents, t.platform, t.created_time, t.process_id "
                 + "FROM task t "
                 + "JOIN process p ON t.process_id = p.process_id "
                 + "WHERE t.process_id = :processId "

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/repository/TaskRepository.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/repository/TaskRepository.java
@@ -11,6 +11,8 @@ public interface TaskRepository {
 
     void updateBy(final Long taskId, final Task task);
 
+    void updateTaskBy(final Long processId, final Long taskId);
+
     List<Task> findAllBy(final Long processId);
 
     List<Process> findProcesses();

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/service/TaskService.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/service/TaskService.java
@@ -1,5 +1,6 @@
 package codesquad.todolist.travelers.task.service;
 
+import codesquad.todolist.travelers.task.domain.dto.request.TaskProcessIdRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskUpdateRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.response.ProcessResponseDto;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskRequestDto;
@@ -32,6 +33,10 @@ public class TaskService {
 
     public void updateTask(final Long taskId, final TaskUpdateRequestDto task) {
         taskRepository.updateBy(taskId, task.toEntity());
+    }
+
+    public void updateTaskByProcess(final TaskProcessIdRequestDto taskProcessIdRequestDto, final Long taskId) {
+        taskRepository.updateTaskBy(taskProcessIdRequestDto.getProcessId(), taskId);
     }
 
     public List<ProcessResponseDto> getProcesses() {


### PR DESCRIPTION
## 구현 내용

- 카드 이동을 위한 기능 구현

## 확인 내용

- RequestBody에 Long 타입만을 넘겨서 받으려면 json에서 {}가 아닌 단일 객체로 보내야 함
- 단순하게 프로세스 아이디만 변경함 (JOIN 사용 X)

## 남은 할 일

- 테스트 코드 작성