### PR TITLE
[BE] fix: Task와 taskId를 담는 TaskPostResponseDto 생성하여 응답 메시지 수정 (#55)

### DIFF
--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/controller/TaskController.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/controller/TaskController.java
@@ -5,6 +5,7 @@ import codesquad.todolist.travelers.task.domain.dto.request.TaskProcessIdRequest
 import codesquad.todolist.travelers.task.domain.dto.request.TaskRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskUpdateRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.response.ProcessResponseDto;
+import codesquad.todolist.travelers.task.domain.dto.response.TaskPostResponseDto;
 import codesquad.todolist.travelers.task.service.TaskService;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -35,10 +36,10 @@ public class TaskController {
 
     @PostMapping("/task")
     public ResponseEntity<ApiResponse<?>> add(@RequestBody final TaskRequestDto taskRequestDto) {
-        Long taskId = taskService.createTask(taskRequestDto);
+        TaskPostResponseDto task = taskService.createTask(taskRequestDto);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.success("200", taskId));
+                .body(ApiResponse.success("200", task));
     }
 
     @DeleteMapping("/task/{taskId}")

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/dto/response/TaskPostResponseDto.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/dto/response/TaskPostResponseDto.java
@@ -1,0 +1,39 @@
+package codesquad.todolist.travelers.task.domain.dto.response;
+
+import codesquad.todolist.travelers.task.domain.entity.Task;
+
+public class TaskPostResponseDto {
+    private final Long taskId;
+    private final Long processId;
+    private final String title;
+    private final String contents;
+    private final String platform;
+
+    public TaskPostResponseDto(final Task task, final Long taskId) {
+        this.taskId = taskId;
+        this.processId = task.getProcessId();
+        this.title = task.getTitle();
+        this.contents = task.getContents();
+        this.platform = task.getPlatform();
+    }
+
+    public Long getProcessId() {
+        return processId;
+    }
+
+    public Long getTaskId() {
+        return taskId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContents() {
+        return contents;
+    }
+
+    public String getPlatform() {
+        return platform;
+    }
+}

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/service/TaskService.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/service/TaskService.java
@@ -4,6 +4,7 @@ import codesquad.todolist.travelers.task.domain.dto.request.TaskProcessIdRequest
 import codesquad.todolist.travelers.task.domain.dto.request.TaskUpdateRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.response.ProcessResponseDto;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskRequestDto;
+import codesquad.todolist.travelers.task.domain.dto.response.TaskPostResponseDto;
 import codesquad.todolist.travelers.task.domain.dto.response.TaskResponseDto;
 import codesquad.todolist.travelers.task.domain.entity.Process;
 import codesquad.todolist.travelers.task.domain.entity.Task;
@@ -23,8 +24,11 @@ public class TaskService {
         this.taskRepository = taskRepository;
     }
 
-    public Long createTask(final TaskRequestDto taskRequestDto) {
-        return taskRepository.save(taskRequestDto.toEntity());
+    public TaskPostResponseDto createTask(final TaskRequestDto taskRequestDto) {
+        Task task = taskRequestDto.toEntity();
+        Long taskId = taskRepository.save(task);
+
+        return new TaskPostResponseDto(task, taskId);
     }
 
     public void deleteTask(final Long taskId) {


### PR DESCRIPTION
## 구현 내용

- POST 응답에서 taskId만 넘어가는 문제 해결
  - Task와 taskId를 담는 TaskPostResponseDto 생성

## 확인 내용

- 트렉젝션으로 save 할 때 문제가 생기면 그 아래 코드인 DTO로 넘어가지 않고 중단되는지 아닌지 명확하지 않습니다

## 남은 할 일

테스트 코드