### PR TITLE
[BE] refactor: AOP 리팩토링 (#81)

### DIFF
--- a/be/travelers/src/main/java/codesquad/todolist/travelers/aspect/HistoryLoggingAspect.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/aspect/HistoryLoggingAspect.java
@@ -1,38 +1,98 @@
 package codesquad.todolist.travelers.aspect;
 
 import codesquad.todolist.travelers.annotation.ActionId;
-import codesquad.todolist.travelers.aspect.dto.TaskServiceHistoryDto;
 import codesquad.todolist.travelers.history.service.HistoryService;
+import codesquad.todolist.travelers.process.service.ProcessService;
+import codesquad.todolist.travelers.task.domain.dto.response.TaskPostResponseDto;
+import codesquad.todolist.travelers.task.domain.entity.Task;
+import codesquad.todolist.travelers.task.service.TaskService;
 import java.lang.reflect.Method;
+import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.aspectj.lang.annotation.Pointcut;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
 
 @Aspect
 @Component
 public class HistoryLoggingAspect {
-    HistoryService historyService;
+    private final HistoryService historyService;
+    private final ProcessService processService;
+    private final TaskService taskService;
 
-    public HistoryLoggingAspect(HistoryService historyService) {
+    public HistoryLoggingAspect(HistoryService historyService, ProcessService processService, TaskService taskService) {
         this.historyService = historyService;
+        this.processService = processService;
+        this.taskService = taskService;
     }
 
-    @Pointcut("execution(public * codesquad.todolist.travelers.task.service.TaskService.*Task*(..))")
-    void allTaskService() {
+    /**
+     * task 이동시 활동기록 저장을 위한 advice 입니다.
+     *
+     * @param proceedingJoinPoint
+     * @return
+     * @throws Throwable
+     * @Around를 사용하여 target 메서드 전후로 활동 기록 저장을 위한 데이터를 처리 합니다.
+     */
+
+    @Around("codesquad.todolist.travelers.aspect.PointCuts.updateTaskByProcessMethodInTaskService()")
+    public Object logHistoryForMove(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        Long taskId = getTaskIdFromArgs(proceedingJoinPoint);
+        Task task = taskService.getTaskBy(taskId);
+        String fromName = processService.findProcessName(task.getProcessId());
+
+        Object result = proceedingJoinPoint.proceed();
+
+        historyService.saveActionMoveHistory(taskId, fromName, getActionId(proceedingJoinPoint).value());
+
+        return result;
     }
 
-    @Around("allTaskService()")
-    public Object logHistory(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
-        MethodSignature methodSignature = (MethodSignature) proceedingJoinPoint.getSignature();
+    /**
+     * task 생성시 활동 기록 저장을 위한 advice 입니다.
+     *
+     * @param joinPoint
+     * @param result
+     * @return
+     * @AfterReturning 을 사용하여 target 메서드의 return 값을 통해 활동 기록을 저장합니다.
+     */
+
+    @AfterReturning(value = "codesquad.todolist.travelers.aspect.PointCuts.createTaskMethodInTaskService()", returning = "result")
+    public Object logHistoryForCreate(JoinPoint joinPoint, Object result) {
+        TaskPostResponseDto taskPostResponseDto = (TaskPostResponseDto) result;
+
+        historyService.saveActionCreateHistory(taskPostResponseDto.getTaskId(), getActionId(joinPoint).value());
+
+        return taskPostResponseDto;
+    }
+
+    /**
+     * task 삭제 또는 수정시 활동 기록 저장을 위한 advice입니다.
+     *
+     * @param joinPoint
+     * @After 를 사용하여 target 메서드 종료후 활동 기록을 저장합니다.
+     */
+
+    @After("codesquad.todolist.travelers.aspect.PointCuts.updateAndDeleteMethodsInTaskService()")
+    public void logHistoryForDeleteAndUpdate(JoinPoint joinPoint) {
+        Long taskId = getTaskIdFromArgs(joinPoint);
+
+        historyService.saveActionDeleteAndUpdateHistory(taskId, getActionId(joinPoint).value());
+    }
+
+    private Long getTaskIdFromArgs(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        return (Long) args[0];
+    }
+
+    private ActionId getActionId(JoinPoint joinPoint) {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
         Method method = methodSignature.getMethod();
         ActionId actionId = method.getAnnotation(ActionId.class);
-
-        Object[] args = proceedingJoinPoint.getArgs();
-        historyService.saveHistory((TaskServiceHistoryDto) args[0], actionId.value());
-        return proceedingJoinPoint.proceed();
+        return actionId;
     }
 
 }

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/aspect/PointCuts.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/aspect/PointCuts.java
@@ -1,0 +1,20 @@
+package codesquad.todolist.travelers.aspect;
+
+import org.aspectj.lang.annotation.Pointcut;
+
+public class PointCuts {
+    @Pointcut("execution(public * codesquad.todolist.travelers.task.service.TaskService.*Task(Long,..))")
+    void updateAndDeleteMethodsInTaskService() {
+    }
+
+    @Pointcut("execution(public * codesquad.todolist.travelers.task.service.TaskService.createTask(..))")
+    void createTaskMethodInTaskService() {
+    }
+
+    /**
+     * move pointcut
+     */
+    @Pointcut("execution(public * codesquad.todolist.travelers.task.service.TaskService.updateTaskByProcess(..))")
+    void updateTaskByProcessMethodInTaskService() {
+    }
+}

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/aspect/dto/TaskServiceHistoryDto.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/aspect/dto/TaskServiceHistoryDto.java
@@ -9,18 +9,12 @@ public class TaskServiceHistoryDto {
     private String title;
     private String from;
     private String to;
-    private Long taskId;
-    private Long fromId;
-    private Long toId;
 
     private TaskServiceHistoryDto(Builder builder) {
         this.actionType = builder.actionType;
         this.title = builder.title;
         this.from = builder.from;
         this.to = builder.to;
-        this.taskId = builder.taskId;
-        this.fromId = builder.fromId;
-        this.toId = builder.toId;
     }
 
     public History toEntity() {
@@ -33,16 +27,7 @@ public class TaskServiceHistoryDto {
                 .build();
     }
 
-    public static TaskServiceHistoryDto of(TaskServiceHistoryDto originalDto, ActionType actionType,
-                                           String fromName) {
-        return TaskServiceHistoryDto.builder()
-                .title(originalDto.getTitle())
-                .from(fromName)
-                .actionType(actionType)
-                .build();
-    }
-
-    public static TaskServiceHistoryDto of(Task task, ActionType actionType, String fromName, String toName) {
+    public static TaskServiceHistoryDto of(Task task, String fromName, String toName, ActionType actionType) {
         return TaskServiceHistoryDto.builder()
                 .title(task.getTitle())
                 .from(fromName)
@@ -51,7 +36,7 @@ public class TaskServiceHistoryDto {
                 .build();
     }
 
-    public static TaskServiceHistoryDto of(Task task, ActionType actionType, String fromName) {
+    public static TaskServiceHistoryDto of(Task task, String fromName, ActionType actionType) {
         return TaskServiceHistoryDto.builder()
                 .title(task.getTitle())
                 .from(fromName)
@@ -66,34 +51,6 @@ public class TaskServiceHistoryDto {
                 .build();
     }
 
-    public ActionType getActionType() {
-        return actionType;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public String getFrom() {
-        return from;
-    }
-
-    public String getTo() {
-        return to;
-    }
-
-    public Long getTaskId() {
-        return taskId;
-    }
-
-    public Long getFromId() {
-        return fromId;
-    }
-
-    public Long getToId() {
-        return toId;
-    }
-
     public static Builder builder() {
         return new Builder();
     }
@@ -101,11 +58,8 @@ public class TaskServiceHistoryDto {
     public static class Builder {
         private ActionType actionType;
         private String title;
-        private Long taskId;
         private String from;
         private String to;
-        private Long fromId;
-        private Long toId;
 
         public Builder actionType(ActionType actionType) {
             this.actionType = actionType;
@@ -117,11 +71,6 @@ public class TaskServiceHistoryDto {
             return this;
         }
 
-        public Builder taskId(Long taskId) {
-            this.taskId = taskId;
-            return this;
-        }
-
         public Builder from(String from) {
             this.from = from;
             return this;
@@ -129,16 +78,6 @@ public class TaskServiceHistoryDto {
 
         public Builder to(String to) {
             this.to = to;
-            return this;
-        }
-
-        public Builder fromId(Long fromId) {
-            this.fromId = fromId;
-            return this;
-        }
-
-        public Builder toId(Long toId) {
-            this.toId = toId;
             return this;
         }
 

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/process/service/ProcessService.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/process/service/ProcessService.java
@@ -1,6 +1,7 @@
 package codesquad.todolist.travelers.process.service;
 
-import static codesquad.todolist.travelers.global.ErrorCode.*;
+import static codesquad.todolist.travelers.global.ErrorCode.FAIL_PROCESS_CREATE;
+import static codesquad.todolist.travelers.global.ErrorCode.NOT_EXIST_PROCESS;
 
 import codesquad.todolist.travelers.global.CustomException;
 import codesquad.todolist.travelers.process.domain.dto.ProcessRequestDto;
@@ -35,5 +36,9 @@ public class ProcessService {
         processRepository.findProcessById(processId).orElseThrow(
                 () -> new CustomException(NOT_EXIST_PROCESS));
         processRepository.deleteProcess(processId);
+    }
+
+    public String findProcessName(Long processId) {
+        return processRepository.findProcessNameBy(processId);
     }
 }

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/controller/TaskController.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/controller/TaskController.java
@@ -1,6 +1,5 @@
 package codesquad.todolist.travelers.task.controller;
 
-import codesquad.todolist.travelers.aspect.dto.TaskServiceHistoryDto;
 import codesquad.todolist.travelers.global.CommonApiResponse;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskProcessIdRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskRequestDto;
@@ -44,11 +43,7 @@ public class TaskController {
     @Operation(summary = "카드 등록", description = "POST 요청으로 각 칼럼(process)에 대한 task를 등록한다.")
     @PostMapping("/task")
     public ResponseEntity<CommonApiResponse<?>> add(@RequestBody @Valid final TaskRequestDto taskRequestDto) {
-        TaskPostResponseDto task = taskService.createTask(
-                TaskServiceHistoryDto.builder()
-                        .title(taskRequestDto.getTitle())
-                        .fromId(taskRequestDto.getProcessId())
-                        .build(), taskRequestDto);
+        TaskPostResponseDto task = taskService.createTask(taskRequestDto);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonApiResponse.success("200", task));
@@ -58,10 +53,7 @@ public class TaskController {
     @Parameter(name = "taskId", description = "카드의 고유 ID")
     @DeleteMapping("/task/{taskId}")
     public ResponseEntity<CommonApiResponse<?>> delete(@PathVariable final Long taskId) {
-        taskService.deleteTask(
-                TaskServiceHistoryDto.builder()
-                        .taskId(taskId)
-                        .build(), taskId);
+        taskService.deleteTask(taskId);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonApiResponse.success("200", "카드 삭제 성공"));
@@ -72,10 +64,7 @@ public class TaskController {
     @PatchMapping("/task/{taskId}")
     public ResponseEntity<CommonApiResponse<?>> update(@PathVariable final Long taskId,
                                                        @RequestBody @Valid final TaskUpdateRequestDto taskUpdateRequestDto) {
-        taskService.updateTask(
-                TaskServiceHistoryDto.builder()
-                        .taskId(taskId)
-                        .build(), taskId, taskUpdateRequestDto);
+        taskService.updateTask(taskId, taskUpdateRequestDto);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonApiResponse.success("200", "카드 수정 성공"));
@@ -86,11 +75,7 @@ public class TaskController {
     @PatchMapping("/task/process/{taskId}")
     public ResponseEntity<CommonApiResponse<?>> move(@PathVariable final Long taskId,
                                                      @RequestBody final TaskProcessIdRequestDto taskProcessIdRequestDto) {
-        taskService.updateTaskByProcess(
-                TaskServiceHistoryDto.builder()
-                        .taskId(taskId)
-                        .toId(taskProcessIdRequestDto.getProcessId())
-                        .build(), taskProcessIdRequestDto, taskId);
+        taskService.updateTaskByProcess(taskId, taskProcessIdRequestDto);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonApiResponse.success("200", "카드 이동 성공"));

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/repository/JdbcTaskRepositoryImpl.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/repository/JdbcTaskRepositoryImpl.java
@@ -35,7 +35,8 @@ public class JdbcTaskRepositoryImpl implements TaskRepository {
 
     @Override
     public void deleteBy(final Long taskId) {
-        String sql = "DELETE FROM task " +
+        String sql = "UPDATE task " +
+                "SET is_deleted = 1 " +
                 "WHERE task_id = :taskId";
 
         template.update(sql, Map.of("taskId", taskId));
@@ -81,7 +82,7 @@ public class JdbcTaskRepositoryImpl implements TaskRepository {
     }
 
     @Override
-    public Task findBy(final Long taskId) {
+    public Task findByIgnoringDeleted(final Long taskId) {
         String sql = "SELECT * FROM task WHERE task_id = :taskId";
 
         return template.queryForObject(sql, Map.of("taskId", taskId), taskRowMapper());

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/repository/TaskRepository.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/domain/repository/TaskRepository.java
@@ -15,6 +15,6 @@ public interface TaskRepository {
 
     List<Task> findAllBy(final Long processId);
 
-    Task findBy(final Long taskId);
+    Task findByIgnoringDeleted(final Long taskId);
 
 }

--- a/be/travelers/src/main/java/codesquad/todolist/travelers/task/service/TaskService.java
+++ b/be/travelers/src/main/java/codesquad/todolist/travelers/task/service/TaskService.java
@@ -2,16 +2,15 @@ package codesquad.todolist.travelers.task.service;
 
 import codesquad.todolist.travelers.ActionType.ActionType;
 import codesquad.todolist.travelers.annotation.ActionId;
-import codesquad.todolist.travelers.aspect.dto.TaskServiceHistoryDto;
 import codesquad.todolist.travelers.global.CustomException;
 import codesquad.todolist.travelers.global.ErrorCode;
 import codesquad.todolist.travelers.process.domain.repository.ProcessRepository;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskProcessIdRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskUpdateRequestDto;
-import codesquad.todolist.travelers.task.domain.dto.response.TasksByProcessResponseDto;
 import codesquad.todolist.travelers.task.domain.dto.response.TaskPostResponseDto;
 import codesquad.todolist.travelers.task.domain.dto.response.TaskResponseDto;
+import codesquad.todolist.travelers.task.domain.dto.response.TasksByProcessResponseDto;
 import codesquad.todolist.travelers.task.domain.entity.Task;
 import codesquad.todolist.travelers.task.domain.repository.TaskRepository;
 import java.util.List;
@@ -31,8 +30,7 @@ public class TaskService {
     }
 
     @ActionId(ActionType.CREATE_TASK)
-    public TaskPostResponseDto createTask(TaskServiceHistoryDto taskServiceHistoryDto,
-                                          final TaskRequestDto taskRequestDto) {
+    public TaskPostResponseDto createTask(final TaskRequestDto taskRequestDto) {
         Task task = TaskRequestDto.toEntity(taskRequestDto);
         Long taskId = taskRepository.save(task).orElseThrow(() -> new CustomException(ErrorCode.FAIL_TASK_CREATE));
 
@@ -40,20 +38,17 @@ public class TaskService {
     }
 
     @ActionId(ActionType.DELETE_TASK)
-    public void deleteTask(TaskServiceHistoryDto taskServiceHistoryDto, final Long taskId) {
+    public void deleteTask(final Long taskId) {
         taskRepository.deleteBy(taskId);
     }
 
     @ActionId(ActionType.UPDATE_TASK)
-    public void updateTask(TaskServiceHistoryDto taskServiceHistoryDto, final Long taskId,
-                           final TaskUpdateRequestDto taskUpdateRequestDto) {
+    public void updateTask(final Long taskId, final TaskUpdateRequestDto taskUpdateRequestDto) {
         taskRepository.updateBy(taskId, TaskUpdateRequestDto.toEntity(taskUpdateRequestDto));
     }
 
     @ActionId(ActionType.MOVE_TASK)
-    public void updateTaskByProcess(TaskServiceHistoryDto taskServiceHistoryDto,
-                                    final TaskProcessIdRequestDto taskProcessIdRequestDto,
-                                    final Long taskId) {
+    public void updateTaskByProcess(final Long taskId, final TaskProcessIdRequestDto taskProcessIdRequestDto) {
         taskRepository.updateTaskBy(taskProcessIdRequestDto.getProcessId(), taskId);
     }
 
@@ -69,5 +64,9 @@ public class TaskService {
                 .stream()
                 .map(TaskResponseDto::fromEntity)
                 .collect(Collectors.toUnmodifiableList());
+    }
+
+    public Task getTaskBy(final Long taskId) {
+        return taskRepository.findByIgnoringDeleted(taskId);
     }
 }

--- a/be/travelers/src/test/java/codesquad/todolist/travelers/task/controller/TaskControllerTest.java
+++ b/be/travelers/src/test/java/codesquad/todolist/travelers/task/controller/TaskControllerTest.java
@@ -9,7 +9,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import codesquad.todolist.travelers.annotation.ControllerTest;
-import codesquad.todolist.travelers.aspect.dto.TaskServiceHistoryDto;
 import codesquad.todolist.travelers.process.domain.entity.Process;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskProcessIdRequestDto;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskRequestDto;
@@ -76,19 +75,6 @@ class TaskControllerTest {
         return new Task(1L, "제목입니다", "내용입니다", "web", LocalDateTime.now(), 1L);
     }
 
-    private TaskServiceHistoryDto dummyTaskServiceHistoryDto(TaskRequestDto taskRequestDto) {
-        return TaskServiceHistoryDto.builder()
-                .title(taskRequestDto.getTitle())
-                .fromId(taskRequestDto.getProcessId())
-                .build();
-    }
-
-    private TaskServiceHistoryDto dummyTaskServiceHistoryDto(Long taskId) {
-        return TaskServiceHistoryDto.builder()
-                .taskId(taskId)
-                .build();
-    }
-
     private TaskRequestDto dummyTaskRequestDto() {
         return new TaskRequestDto("제목입니다", "내용입니다", "web", 1L);
     }
@@ -104,7 +90,7 @@ class TaskControllerTest {
     @DisplayName("카드를 생성하면 해당 카드의 정보가 반환된다.")
     void createTask() throws Exception {
 
-        given(taskService.createTask(any(), any()))
+        given(taskService.createTask(any()))
                 .willReturn(dummyTaskPostResponseDto());
 
         // when
@@ -130,7 +116,7 @@ class TaskControllerTest {
     @DisplayName("카드를 삭제할 수 있다.")
     void deleteTask() throws Exception {
         // given
-        doNothing().when(taskService).deleteTask(dummyTaskServiceHistoryDto(1L), 1L);
+        doNothing().when(taskService).deleteTask(1L);
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -152,9 +138,8 @@ class TaskControllerTest {
     @Test
     @DisplayName("PATCH 요청으로 고유 ID(taskId)에 따른 카드를 수정한다.")
     void updateSuccessTest() throws Exception {
-        // given
-        doNothing().when(taskService)
-                .updateTask(dummyTaskServiceHistoryDto(dummyTaskRequestDto()), 1L, dummyTaskUpdateRequestDto());
+        //given
+        doNothing().when(taskService).updateTask(1L, dummyTaskUpdateRequestDto());
 
         // when
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders
@@ -180,8 +165,7 @@ class TaskControllerTest {
     void moveSuccessTest() throws Exception {
         // given
         doNothing().when(taskService)
-                .updateTaskByProcess(dummyTaskServiceHistoryDto(dummyTaskRequestDto()),
-                        dummyTaskProcessIdRequestDto(), 1L);
+                .updateTaskByProcess(1L, dummyTaskProcessIdRequestDto());
 
         // when
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders

--- a/be/travelers/src/test/java/codesquad/todolist/travelers/task/domain/repository/JdbcTaskRepositoryImplTest.java
+++ b/be/travelers/src/test/java/codesquad/todolist/travelers/task/domain/repository/JdbcTaskRepositoryImplTest.java
@@ -21,7 +21,7 @@ class JdbcTaskRepositoryImplTest {
         //when
         Long taskId = repository.save(expected).get();
         //then
-        Task actual = repository.findBy(taskId);
+        Task actual = repository.findByIgnoringDeleted(taskId);
 
         Assertions.assertThat(actual)
                 .usingRecursiveComparison() // 값 하나씩 돌면서 비교해주는 메서드

--- a/be/travelers/src/test/java/codesquad/todolist/travelers/task/service/TaskServiceTest.java
+++ b/be/travelers/src/test/java/codesquad/todolist/travelers/task/service/TaskServiceTest.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import codesquad.todolist.travelers.annotation.ServiceTest;
-import codesquad.todolist.travelers.aspect.dto.TaskServiceHistoryDto;
 import codesquad.todolist.travelers.process.domain.entity.Process;
 import codesquad.todolist.travelers.process.domain.repository.ProcessRepository;
 import codesquad.todolist.travelers.task.domain.dto.request.TaskRequestDto;
@@ -42,7 +41,7 @@ class TaskServiceTest {
         given(taskRepository.save(any())).willReturn(Optional.ofNullable(dummyTask().getTaskId()));
 
         //when
-        taskService.createTask(dummyTaskServiceHistoryDto(), dummyTaskRequestDto());
+        taskService.createTask(dummyTaskRequestDto());
 
         //then
         Assertions.assertThat(1L).isEqualTo(dummyTask().getTaskId());
@@ -50,11 +49,6 @@ class TaskServiceTest {
 
     private Task dummyTask() {
         return new Task(1L, "제목입니다", "내용입니다", "web", LocalDateTime.now(), 1L);
-    }
-
-    private TaskServiceHistoryDto dummyTaskServiceHistoryDto() {
-        return TaskServiceHistoryDto.builder()
-                .build();
     }
 
     private TaskRequestDto dummyTaskRequestDto() {

--- a/be/travelers/src/test/resources/schema.sql
+++ b/be/travelers/src/test/resources/schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS `task`
     `platform`     VARCHAR(20)                        NOT NULL,
     `created_time` DATETIME DEFAULT CURRENT_TIMESTAMP NULL,
     `process_id`   BIGINT                             NOT NULL,
+    `is_deleted`   TINYINT(1)                         DEFAULT 0,
     CONSTRAINT `fk_Task_process_id`
     FOREIGN KEY (`process_id`) REFERENCES `process` (`process_id`)
     );


### PR DESCRIPTION
## 구현 내용

- TaskController에서 TaskServiceHistoryDto를 생성하지 않도록 수정했다.
- TaskService에서 사용하지 않는 TaskServiceHistoryDto를 파라미터로 받지 않도록 수정했다.
- advice를 Action 별로 분리했다. 
- task 삭제시 실제 DB에서 삭제가 아닌 soft-delete을 통해 삭제되도록 수정했다.  

## 남은 할 일

- test코드 작성
- 카드 이동 구현 